### PR TITLE
Fix Elementor widget constant and load integrations

### DIFF
--- a/includes/class-sh-elementor.php
+++ b/includes/class-sh-elementor.php
@@ -16,7 +16,7 @@ class SH_Elementor_Widget extends Widget_Base {
         $this->start_controls_section('style_section',['label'=>'Style','tab'=>Controls_Manager::TAB_STYLE]);
         $this->add_control('text_color',['label'=>'Text Color','type'=>Controls_Manager::COLOR]);
         $this->add_control('bg_color',['label'=>'Background Color','type'=>Controls_Manager::COLOR]);
-        $this->add_control('border_color',['label'=>'Border Color','type'=>Controls_Manager::TAB_COLOR]);
+        $this->add_control('border_color',['label'=>'Border Color','type'=>Controls_Manager::COLOR]);
         $this->add_group_control(Group_Control_Typography::get_type(), ['name'=>'typo','selector'=>'{{WRAPPER}}']);
         $this->add_control('padding',['label'=>'Padding','type'=>Controls_Manager::SLIDER,'size_units'=>['px']]);
         $this->add_control('margin',['label'=>'Margin','type'=>Controls_Manager::SLIDER,'size_units'=>['px']]);

--- a/simple-hours.php
+++ b/simple-hours.php
@@ -24,5 +24,8 @@ require_once SH_DIR . 'includes/class-sh-settings.php';
 require_once SH_DIR . 'includes/class-sh-shortcodes.php';
 require_once SH_DIR . 'includes/class-sh-schema.php';
 require_once SH_DIR . 'includes/class-sh-logger.php';
+require_once SH_DIR . 'includes/class-sh-elementor.php';
 
 add_action( 'plugins_loaded', array( 'SH_Shortcodes', 'init' ) );
+add_action( 'init', array( 'SH_Shortcodes', 'register_gutenberg_blocks' ) );
+add_action( 'elementor/widgets/register', array( 'SH_Elementor_Widget', 'register_widget' ) );


### PR DESCRIPTION
## Summary
- fix constant name for border color control
- include Elementor class
- hook up block and widget registration

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `phpunit -c phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846c8f9af94832cac5637117972c8c8