### PR TITLE
Add conditional Elementor loading

### DIFF
--- a/simple-hours.php
+++ b/simple-hours.php
@@ -24,8 +24,21 @@ require_once SH_DIR . 'includes/class-sh-settings.php';
 require_once SH_DIR . 'includes/class-sh-shortcodes.php';
 require_once SH_DIR . 'includes/class-sh-schema.php';
 require_once SH_DIR . 'includes/class-sh-logger.php';
-require_once SH_DIR . 'includes/class-sh-elementor.php';
 
 add_action( 'plugins_loaded', array( 'SH_Shortcodes', 'init' ) );
 add_action( 'init', array( 'SH_Shortcodes', 'register_gutenberg_blocks' ) );
-add_action( 'elementor/widgets/register', array( 'SH_Elementor_Widget', 'register_widget' ) );
+
+/**
+ * Load Elementor integration only when Elementor is active.
+ */
+function sh_maybe_load_elementor_widget() {
+    if ( class_exists( '\\Elementor\\Widget_Base' ) || did_action( 'elementor/loaded' ) ) {
+        require_once SH_DIR . 'includes/class-sh-elementor.php';
+        add_action( 'elementor/widgets/register', array( 'SH_Elementor_Widget', 'register_widget' ) );
+    } else {
+        add_action( 'admin_notices', function() {
+            echo '<div class="notice notice-warning"><p>' . esc_html__( 'Elementor must be active for Simple Hours widget.', 'simple-hours' ) . '</p></div>';
+        } );
+    }
+}
+add_action( 'plugins_loaded', 'sh_maybe_load_elementor_widget' );


### PR DESCRIPTION
## Summary
- load Elementor widget only when Elementor is active
- show an admin notice if Elementor is missing

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846cdae9628832c92be9525df5f306e