### PR TITLE
Fix schema foreach warning

### DIFF
--- a/includes/class-sh-schema.php
+++ b/includes/class-sh-schema.php
@@ -6,24 +6,34 @@ class SH_Schema {
     public function output_schema(){
         list($weekly, $holidays) = SH_Shortcodes::get_data();
         $schema = array();
-        foreach($weekly as $day=>$v){
-            if (!empty($v['closed'])) continue;
-            $schema[] = array(
-                '@type'=>'OpeningHoursSpecification',
-                'dayOfWeek'=> $day,
-                'opens'=> $v['open'],
-                'closes'=> $v['close'],
-            );
+
+        if (is_array($weekly)) {
+            foreach ($weekly as $day => $v) {
+                if (!empty($v['closed'])) {
+                    continue;
+                }
+                $schema[] = array(
+                    '@type'     => 'OpeningHoursSpecification',
+                    'dayOfWeek' => $day,
+                    'opens'     => $v['open'],
+                    'closes'    => $v['close'],
+                );
+            }
         }
-        foreach($holidays as $h){
-            if (isset($h['closed'])) continue;
-            $schema[] = array(
-                '@type'=>'OpeningHoursSpecification',
-                'validFrom'=>$h['from'],
-                'validThrough'=>$h['to'],
-                'opens'=>$h['open'],
-                'closes'=>$h['close'],
-            );
+
+        if (is_array($holidays)) {
+            foreach ($holidays as $h) {
+                if (isset($h['closed'])) {
+                    continue;
+                }
+                $schema[] = array(
+                    '@type'        => 'OpeningHoursSpecification',
+                    'validFrom'    => $h['from'],
+                    'validThrough' => $h['to'],
+                    'opens'        => $h['open'],
+                    'closes'       => $h['close'],
+                );
+            }
         }
         echo "<script type='application/ld+json'>".json_encode($schema)."</script>";
     }


### PR DESCRIPTION
## Summary
- guard loops on Weekly Hours and Holiday Overrides
- avoid warnings when options aren't arrays

## Testing
- `php -l includes/class-sh-schema.php`
- `php -l includes/class-sh-shortcodes.php`
- `phpunit -c phpunit.xml` *(fails: `Please set WP_TESTS_DIR environment variable.`)*

------
https://chatgpt.com/codex/tasks/task_b_6846d216b404832cb75dfdd46a79f0b5