### PR TITLE
Add Elementor widget for hours display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
   - `[simplehours_until]`
   - `[simplehours_fullweek]`
 
+- Elementor:
+  - Add the **Simple Hours** widget and choose the output format along with text or table styling.
+
 
 ## Filters & Actions
 

--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -1,0 +1,117 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SH_Elementor_Widget extends \Elementor\Widget_Base {
+    public function get_name() {
+        return 'simple_hours';
+    }
+
+    public function get_title() {
+        return __( 'Simple Hours', 'simple-hours' );
+    }
+
+    public function get_icon() {
+        return 'eicon-clock';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section( 'content_section', [
+            'label' => __( 'Content', 'simple-hours' ),
+        ] );
+
+        $this->add_control( 'format', [
+            'label'   => __( 'Format', 'simple-hours' ),
+            'type'    => \Elementor\Controls_Manager::SELECT,
+            'default' => 'today',
+            'options' => [
+                'today'    => __( 'Today', 'simple-hours' ),
+                'until'    => __( 'Until', 'simple-hours' ),
+                'fullweek' => __( 'Full Week', 'simple-hours' ),
+            ],
+        ] );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section( 'text_style', [
+            'label'     => __( 'Text', 'simple-hours' ),
+            'tab'       => \Elementor\Controls_Manager::TAB_STYLE,
+            'condition' => [ 'format!' => 'fullweek' ],
+        ] );
+
+        $this->add_group_control( \Elementor\Group_Control_Typography::get_type(), [
+            'name'     => 'text_typography',
+            'selector' => '{{WRAPPER}} .simple-hours-output',
+        ] );
+
+        $this->add_control( 'text_color', [
+            'label'     => __( 'Text Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .simple-hours-output' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section( 'table_style', [
+            'label'     => __( 'Table', 'simple-hours' ),
+            'tab'       => \Elementor\Controls_Manager::TAB_STYLE,
+            'condition' => [ 'format' => 'fullweek' ],
+        ] );
+
+        $this->add_group_control( \Elementor\Group_Control_Typography::get_type(), [
+            'name'     => 'table_typography',
+            'selector' => '{{WRAPPER}} table.simple-hours-table, {{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td',
+        ] );
+
+        $this->add_control( 'table_text_color', [
+            'label'     => __( 'Text Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'table_bg_color', [
+            'label'     => __( 'Background Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table' => 'background-color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_group_control( \Elementor\Group_Control_Border::get_type(), [
+            'name'     => 'table_border',
+            'selector' => '{{WRAPPER}} table.simple-hours-table, {{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td',
+        ] );
+
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        $format   = isset( $settings['format'] ) ? $settings['format'] : 'today';
+        switch ( $format ) {
+            case 'until':
+                $out = SH_Shortcodes::until();
+                echo '<div class="simple-hours-output">' . $out . '</div>';
+                break;
+            case 'fullweek':
+                $out = SH_Shortcodes::fullweek();
+                $out = str_replace( '<table>', '<table class="simple-hours-table">', $out );
+                echo $out;
+                break;
+            case 'today':
+            default:
+                $out = SH_Shortcodes::today();
+                echo '<div class="simple-hours-output">' . $out . '</div>';
+                break;
+        }
+    }
+}

--- a/simple-hours.php
+++ b/simple-hours.php
@@ -27,4 +27,9 @@ require_once SH_DIR . 'includes/class-sh-logger.php';
 
 add_action( 'plugins_loaded', array( 'SH_Shortcodes', 'init' ) );
 
+add_action( 'elementor/widgets/register', function( $widgets_manager ) {
+    require_once SH_DIR . 'includes/class-sh-elementor-widget.php';
+    $widgets_manager->register( new SH_Elementor_Widget() );
+} );
+
 


### PR DESCRIPTION
## Summary
- Add Elementor widget to render Simple Hours in multiple formats
- Register the widget with Elementor
- Document widget usage in README

## Testing
- `php -l includes/class-sh-elementor-widget.php simple-hours.php`
- `phpunit` *(fails: wp-tests-config.php is missing)*

------
https://chatgpt.com/codex/tasks/task_b_68be84312690832c8397f7de00f69298