### PR TITLE
Rename plugin to Stoke Simple Hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Simple Hours Plugin
+# Stoke Simple Hours Plugin
 
 ## Installation
 
 1. Upload the `simple-hours` folder to your `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to Settings → Simple Hours to configure your weekly hours and holiday overrides.
+3. Go to Settings → Stoke Simple Hours to configure your weekly hours and holiday overrides.
 
 ## Usage
 
 - Shortcodes:
-  - `[simplehours_today]`
-  - `[simplehours_until]`
-  - `[simplehours_fullweek]`
+  - `[simplehours_today]` – Today's hours
+  - `[simplehours_until]` – Open today until
+  - `[simplehours_fullweek]` – Full week table
 
 - Elementor:
-  - Add the **Simple Hours** widget and choose the output format along with text or table styling.
+  - Add the **Stoke Simple Hours** widget and choose the output format along with text or table styling.
 
 
 ## Filters & Actions

--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -9,7 +9,7 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
     }
 
     public function get_title() {
-        return __( 'Simple Hours', 'simple-hours' );
+        return __( 'Stoke Simple Hours', 'simple-hours' );
     }
 
     public function get_icon() {
@@ -30,9 +30,9 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'type'    => \Elementor\Controls_Manager::SELECT,
             'default' => 'today',
             'options' => [
-                'today'    => __( 'Today', 'simple-hours' ),
-                'until'    => __( 'Until', 'simple-hours' ),
-                'fullweek' => __( 'Full Week', 'simple-hours' ),
+                'today'    => __( "Today's Hours", 'simple-hours' ),
+                'until'    => __( 'Open Today Until', 'simple-hours' ),
+                'fullweek' => __( 'Full Week Table', 'simple-hours' ),
             ],
         ] );
 

--- a/includes/class-sh-settings.php
+++ b/includes/class-sh-settings.php
@@ -11,7 +11,7 @@ class SH_Settings {
     }
 
     public function add_admin_menu(){
-        add_options_page('Simple Hours', 'Simple Hours', 'manage_options', 'simple_hours', array($this,'options_page'));
+        add_options_page('Stoke Simple Hours', 'Stoke Simple Hours', 'manage_options', 'simple_hours', array($this,'options_page'));
     }
 
     public function settings_init(){
@@ -86,8 +86,8 @@ class SH_Settings {
         echo '<p>Use these shortcodes to display opening hours:</p>';
         echo '<ul>';
         echo '<li><code>[simplehours_today]</code> – e.g. “We\'re open from 9:00 to 17:00.”</li>';
-        echo '<li><code>[simplehours_until]</code> – e.g. “Open until 17:00.”</li>';
-        echo '<li><code>[simplehours_fullweek]</code> – outputs a weekly table of hours.</li>';
+        echo '<li><code>[simplehours_until]</code> – e.g. “Open today until 17:00.”</li>';
+        echo '<li><code>[simplehours_fullweek]</code> – outputs a full week table of hours.</li>';
         echo '</ul>';
     }
 
@@ -99,7 +99,7 @@ class SH_Settings {
     public function options_page(){
         ?>
         <div class="wrap">
-            <h1>Simple Hours Settings</h1>
+            <h1>Stoke Simple Hours Settings</h1>
             <form method="post" action="options.php">
             <?php
             settings_fields('sh_settings');

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -47,7 +47,7 @@ class SH_Shortcodes {
                         return "Next open at " . self::get_open_time($weekly, $holidays, $tom);
                     }
                     if ($time < $h['close']){
-                        return "Open until {$h['close']}.";
+                        return "Open today until {$h['close']}.";
                     }
                     return "Next open at " . self::get_open_time($weekly, $holidays, $today);
                 }
@@ -75,7 +75,7 @@ class SH_Shortcodes {
             }
         }
         if ($time < $weekly[$day]['close']){
-            return "Open until " . $weekly[$day]['close'] . ".";
+            return "Open today until " . $weekly[$day]['close'] . ".";
         }
     }
 

--- a/simple-hours.php
+++ b/simple-hours.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Simple Hours
+Plugin Name: Stoke Simple Hours
 Description: Lean plugin for setting weekly hours and holiday overrides.
 Version: 1.0
 Author: Stoke Design Co


### PR DESCRIPTION
## Summary
- rename widget format labels to "Today's Hours", "Open Today Until", and "Full Week Table"
- update shortcode output and settings references for the new phrasing
- document shortcode descriptions in README

## Testing
- `phpunit` *(fails: Please set WP_TESTS_DIR environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68be86fb495c832ca30b5bbbd705b6b4