### PR TITLE
Enhance table styling controls and current day highlight

### DIFF
--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -57,6 +57,19 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             ],
         ] );
 
+        $this->add_responsive_control( 'text_align', [
+            'label'     => __( 'Text Alignment', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::CHOOSE,
+            'options'   => [
+                'left'   => [ 'title' => __( 'Left', 'simple-hours' ),   'icon' => 'eicon-text-align-left' ],
+                'center' => [ 'title' => __( 'Center', 'simple-hours' ), 'icon' => 'eicon-text-align-center' ],
+                'right'  => [ 'title' => __( 'Right', 'simple-hours' ),  'icon' => 'eicon-text-align-right' ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .simple-hours-output' => 'text-align: {{VALUE}};',
+            ],
+        ] );
+
         $this->end_controls_section();
 
         $this->start_controls_section( 'table_style', [
@@ -66,29 +79,192 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
         ] );
 
         $this->add_group_control( \Elementor\Group_Control_Typography::get_type(), [
-            'name'     => 'table_typography',
-            'selector' => '{{WRAPPER}} table.simple-hours-table, {{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td',
+            'name'     => 'day_typography',
+            'selector' => '{{WRAPPER}} table.simple-hours-table th',
         ] );
 
-        $this->add_control( 'table_text_color', [
-            'label'     => __( 'Text Color', 'simple-hours' ),
+        $this->add_control( 'day_color', [
+            'label'     => __( 'Day Text Color', 'simple-hours' ),
             'type'      => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} table.simple-hours-table' => 'color: {{VALUE}};',
+                '{{WRAPPER}} table.simple-hours-table th' => 'color: {{VALUE}};',
             ],
         ] );
 
-        $this->add_control( 'table_bg_color', [
-            'label'     => __( 'Background Color', 'simple-hours' ),
+        $this->add_responsive_control( 'day_align', [
+            'label'     => __( 'Day Text Align', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::CHOOSE,
+            'options'   => [
+                'left'   => [ 'title' => __( 'Left', 'simple-hours' ),   'icon' => 'eicon-text-align-left' ],
+                'center' => [ 'title' => __( 'Center', 'simple-hours' ), 'icon' => 'eicon-text-align-center' ],
+                'right'  => [ 'title' => __( 'Right', 'simple-hours' ),  'icon' => 'eicon-text-align-right' ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table th' => 'text-align: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_group_control( \Elementor\Group_Control_Typography::get_type(), [
+            'name'     => 'time_typography',
+            'selector' => '{{WRAPPER}} table.simple-hours-table td',
+        ] );
+
+        $this->add_control( 'time_color', [
+            'label'     => __( 'Time Text Color', 'simple-hours' ),
             'type'      => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} table.simple-hours-table' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} table.simple-hours-table td' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'time_align', [
+            'label'     => __( 'Time Text Align', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::CHOOSE,
+            'options'   => [
+                'left'   => [ 'title' => __( 'Left', 'simple-hours' ),   'icon' => 'eicon-text-align-left' ],
+                'center' => [ 'title' => __( 'Center', 'simple-hours' ), 'icon' => 'eicon-text-align-center' ],
+                'right'  => [ 'title' => __( 'Right', 'simple-hours' ),  'icon' => 'eicon-text-align-right' ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table td' => 'text-align: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'table_width', [
+            'label' => __( 'Table Width', 'simple-hours' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ '%', 'px' ],
+            'range' => [
+                '%' => [ 'min' => 10, 'max' => 100 ],
+                'px' => [ 'min' => 0, 'max' => 1000 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table' => 'width: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_control( 'row_color_1', [
+            'label'     => __( 'Row Colour 1', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr:nth-child(odd)' => 'background-color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'row_color_2', [
+            'label'     => __( 'Row Colour 2', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr:nth-child(even)' => 'background-color: {{VALUE}};',
             ],
         ] );
 
         $this->add_group_control( \Elementor\Group_Control_Border::get_type(), [
-            'name'     => 'table_border',
-            'selector' => '{{WRAPPER}} table.simple-hours-table, {{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td',
+            'name'     => 'outer_border',
+            'selector' => '{{WRAPPER}} table.simple-hours-table',
+        ] );
+
+        $this->add_control( 'row_border_color', [
+            'label'     => __( 'Row Border Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr' => 'border-bottom-color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'row_border_style', [
+            'label'   => __( 'Row Border Style', 'simple-hours' ),
+            'type'    => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                'none'   => __( 'None', 'simple-hours' ),
+                'solid'  => __( 'Solid', 'simple-hours' ),
+                'dashed' => __( 'Dashed', 'simple-hours' ),
+                'dotted' => __( 'Dotted', 'simple-hours' ),
+                'double' => __( 'Double', 'simple-hours' ),
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr' => 'border-bottom-style: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'row_border_width', [
+            'label' => __( 'Row Border Width', 'simple-hours' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 10 ] ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr' => 'border-bottom-width: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_control( 'vertical_border_color', [
+            'label'     => __( 'Vertical Border Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td' => 'border-right-color: {{VALUE}};',
+                '{{WRAPPER}} table.simple-hours-table th:last-child, {{WRAPPER}} table.simple-hours-table td:last-child' => 'border-right-color: transparent;',
+            ],
+        ] );
+
+        $this->add_control( 'vertical_border_style', [
+            'label'   => __( 'Vertical Border Style', 'simple-hours' ),
+            'type'    => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                'none'   => __( 'None', 'simple-hours' ),
+                'solid'  => __( 'Solid', 'simple-hours' ),
+                'dashed' => __( 'Dashed', 'simple-hours' ),
+                'dotted' => __( 'Dotted', 'simple-hours' ),
+                'double' => __( 'Double', 'simple-hours' ),
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td' => 'border-right-style: {{VALUE}};',
+                '{{WRAPPER}} table.simple-hours-table th:last-child, {{WRAPPER}} table.simple-hours-table td:last-child' => 'border-right-style: none;',
+            ],
+        ] );
+
+        $this->add_control( 'vertical_border_width', [
+            'label' => __( 'Vertical Border Width', 'simple-hours' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 10 ] ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table th, {{WRAPPER}} table.simple-hours-table td' => 'border-right-width: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} table.simple-hours-table th:last-child, {{WRAPPER}} table.simple-hours-table td:last-child' => 'border-right-width: 0;',
+            ],
+        ] );
+
+        $this->add_control( 'current_day_bg', [
+            'label'     => __( 'Current Day Background', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day' => 'background-color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_group_control( \Elementor\Group_Control_Typography::get_type(), [
+            'name'     => 'current_day_typography',
+            'selector' => '{{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day th, {{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day td',
+        ] );
+
+        $this->add_control( 'current_day_color', [
+            'label'     => __( 'Current Day Text Color', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day, {{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day th, {{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day td' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'current_day_align', [
+            'label'     => __( 'Current Day Text Align', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::CHOOSE,
+            'options'   => [
+                'left'   => [ 'title' => __( 'Left', 'simple-hours' ),   'icon' => 'eicon-text-align-left' ],
+                'center' => [ 'title' => __( 'Center', 'simple-hours' ), 'icon' => 'eicon-text-align-center' ],
+                'right'  => [ 'title' => __( 'Right', 'simple-hours' ),  'icon' => 'eicon-text-align-right' ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day th, {{WRAPPER}} table.simple-hours-table tr.simple-hours-current-day td' => 'text-align: {{VALUE}};',
+            ],
         ] );
 
         $this->end_controls_section();
@@ -104,7 +280,6 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
                 break;
             case 'fullweek':
                 $out = SH_Shortcodes::fullweek();
-                $out = str_replace( '<table>', '<table class="simple-hours-table">', $out );
                 echo $out;
                 break;
             case 'today':

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -93,16 +93,18 @@ class SH_Shortcodes {
 
     public static function fullweek(){
         list($weekly,) = self::get_data();
-        $out = '<table>';
+        $out         = '<table class="simple-hours-table">';
+        $current_day = date('l');
 
         if (is_array($weekly)) {
             foreach ($weekly as $day => $v) {
+                $row_class = $day === $current_day ? ' class="simple-hours-current-day"' : '';
                 if (!empty($v['closed'])) {
                     $hours = 'Closed';
                 } else {
                     $hours = "{$v['open']} - {$v['close']}";
                 }
-                $out .= "<tr><th>$day</th><td>$hours</td></tr>";
+                $out .= "<tr{$row_class}><th class=\"simple-hours-day\">$day</th><td class=\"simple-hours-time\">$hours</td></tr>";
             }
         }
 

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -19,4 +19,9 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         $this->assertIsString($output);
         $this->assertNotEmpty($output);
     }
+
+    public function test_fullweek_has_current_day_class() {
+        $output = do_shortcode('[simplehours_fullweek]');
+        $this->assertStringContainsString('simple-hours-current-day', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- add granular table style controls including column typography, row colours, borders and width
- support custom current day highlight styles
- add test for current day markup

## Testing
- `phpunit` *(fails: command not found)*
- `sudo apt-get install -y phpunit` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68be93174704832ca3f82777ea682969