### PR TITLE
Fix icon rendering and table styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/simple-hours.css
+++ b/assets/simple-hours.css
@@ -1,0 +1,8 @@
+table.simple-hours-table,
+table.simple-hours-table th,
+table.simple-hours-table td,
+table.simple-hours-table tr {
+    border: none;
+    background: none;
+    padding: 0;
+}

--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -92,11 +92,21 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'condition' => [ 'text_icon[value]!' => '' ],
         ] );
 
-        $this->add_control( 'icon_color', [
-            'label'     => __( 'Icon Color', 'simple-hours' ),
+        $this->add_control( 'icon_color_open', [
+            'label'     => __( 'Icon Color (Open)', 'simple-hours' ),
             'type'      => \Elementor\Controls_Manager::COLOR,
+            'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
-                '{{WRAPPER}} .simple-hours-output .simple-hours-icon' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'icon_color_closed', [
+            'label'     => __( 'Icon Color (Closed)', 'simple-hours' ),
+            'type'      => \Elementor\Controls_Manager::COLOR,
+            'condition' => [ 'text_icon[value]!' => '' ],
+            'selectors' => [
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed' => 'color: {{VALUE}};',
             ],
         ] );
 
@@ -104,6 +114,7 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'label' => __( 'Icon Size', 'simple-hours' ),
             'type'  => \Elementor\Controls_Manager::SLIDER,
             'range' => [ 'px' => [ 'min' => 6, 'max' => 100 ] ],
+            'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon' => 'font-size: {{SIZE}}{{UNIT}};',
             ],
@@ -348,10 +359,13 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
 
         $icon = '';
         if ( ! empty( $settings['text_icon']['value'] ) ) {
-            $icon = \Elementor\Icons_Manager::render_icon(
+            $is_open   = SH_Shortcodes::is_open();
+            $icon_class = $is_open ? 'simple-hours-icon simple-hours-icon-open' : 'simple-hours-icon simple-hours-icon-closed';
+            $icon      = \Elementor\Icons_Manager::render_icon(
                 $settings['text_icon'],
-                [ 'aria-hidden' => 'true', 'class' => 'simple-hours-icon' ],
-                'span'
+                [ 'aria-hidden' => 'true', 'class' => $icon_class ],
+                'span',
+                false
             );
         }
 

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -91,6 +91,27 @@ class SH_Shortcodes {
         return $weekly[$dn]['open'];
     }
 
+    public static function is_open($timestamp = null){
+        list($weekly, $holidays) = self::get_data();
+        $ts      = $timestamp ? $timestamp : time();
+        $today   = date('Y-m-d', $ts);
+        $time    = date('H:i', $ts);
+        $dayname = date('l', $ts);
+
+        if (is_array($holidays)) {
+            foreach ($holidays as $h) {
+                if ($today >= $h['from'] && $today <= $h['to']){
+                    if (isset($h['closed'])) return false;
+                    return ($time >= $h['open'] && $time < $h['close']);
+                }
+            }
+        }
+        if (!empty($weekly[$dayname]['closed'])){
+            return false;
+        }
+        return ($time >= $weekly[$dayname]['open'] && $time < $weekly[$dayname]['close']);
+    }
+
     public static function fullweek(){
         list($weekly,) = self::get_data();
         $out         = '<table class="simple-hours-table">';

--- a/simple-hours.php
+++ b/simple-hours.php
@@ -32,4 +32,8 @@ add_action( 'elementor/widgets/register', function( $widgets_manager ) {
     $widgets_manager->register( new SH_Elementor_Widget() );
 } );
 
+add_action( 'wp_enqueue_scripts', function() {
+    wp_enqueue_style( 'simple-hours', SH_URL . 'assets/simple-hours.css', array(), '1.0' );
+} );
+
 

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -24,4 +24,14 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         $output = do_shortcode('[simplehours_fullweek]');
         $this->assertStringContainsString('simple-hours-current-day', $output);
     }
+
+    public function test_is_open() {
+        $open_time  = strtotime('2023-06-26 10:00:00'); // Monday 10:00
+        $closed_time = strtotime('2023-06-26 18:00:00'); // Monday 18:00
+        $weekend_time = strtotime('2023-06-24 10:00:00'); // Saturday
+
+        $this->assertTrue( SH_Shortcodes::is_open( $open_time ) );
+        $this->assertFalse( SH_Shortcodes::is_open( $closed_time ) );
+        $this->assertFalse( SH_Shortcodes::is_open( $weekend_time ) );
+    }
 }


### PR DESCRIPTION
## Summary
- Fix Elementor icon rendering to prevent stray `1` and allow size and dual color controls
- Add `SH_Shortcodes::is_open` helper and tests
- Remove default table borders/background via new stylesheet

## Testing
- `php -l includes/class-sh-elementor-widget.php`
- `php -l includes/class-sh-shortcodes.php`
- `php -l simple-hours.php`
- `php -l tests/test-shortcodes.php`
- `phpunit` *(fails: Please set WP_TESTS_DIR environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68be9e93f8bc832cb145e29d765ee6a9