### PR TITLE
Allow Elementor widget icon color and size controls

### DIFF
--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -98,6 +98,7 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open i' => 'color: {{VALUE}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open svg' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
             ],
         ] );
@@ -108,6 +109,7 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed i' => 'color: {{VALUE}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed svg' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
             ],
         ] );
@@ -115,10 +117,18 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
         $this->add_control( 'icon_size', [
             'label' => __( 'Icon Size', 'simple-hours' ),
             'type'  => \Elementor\Controls_Manager::SLIDER,
-            'range' => [ 'px' => [ 'min' => 6, 'max' => 100 ] ],
+            'size_units' => [ 'px', 'em', 'rem', '%' ],
+            'range' => [
+                'px'  => [ 'min' => 6,  'max' => 100 ],
+                'em'  => [ 'min' => 0.5, 'max' => 10 ],
+                'rem' => [ 'min' => 0.5, 'max' => 10 ],
+                '%'   => [ 'min' => 10, 'max' => 200 ],
+            ],
+            'default' => [ 'size' => 20, 'unit' => 'px' ],
             'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon i' => 'font-size: {{SIZE}}{{UNIT}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon svg' => 'width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ] );


### PR DESCRIPTION
## Summary
- ensure icon color applies to both SVGs and font icons
- add units and default size for icon size slider

## Testing
- `php -l includes/class-sh-elementor-widget.php`
- `phpunit` *(fails: Please set WP_TESTS_DIR environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68bea504e488832c8fcf8ceca72b5627