### PR TITLE
Allow Elementor widget icon color and size controls

### DIFF
--- a/includes/class-sh-elementor-widget.php
+++ b/includes/class-sh-elementor-widget.php
@@ -99,6 +99,7 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open' => 'color: {{VALUE}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open svg' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-open svg *' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
             ],
         ] );
 
@@ -109,16 +110,24 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed' => 'color: {{VALUE}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed svg' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon-closed svg *' => 'fill: {{VALUE}}; stroke: {{VALUE}};',
             ],
         ] );
 
         $this->add_control( 'icon_size', [
             'label' => __( 'Icon Size', 'simple-hours' ),
             'type'  => \Elementor\Controls_Manager::SLIDER,
-            'range' => [ 'px' => [ 'min' => 6, 'max' => 100 ] ],
+            'size_units' => [ 'px', 'em', 'rem', '%' ],
+            'range' => [
+                'px'  => [ 'min' => 6,  'max' => 100 ],
+                'em'  => [ 'min' => 0.5, 'max' => 10 ],
+                'rem' => [ 'min' => 0.5, 'max' => 10 ],
+                '%'   => [ 'min' => 10, 'max' => 200 ],
+            ],
+            'default' => [ 'size' => 20, 'unit' => 'px' ],
             'condition' => [ 'text_icon[value]!' => '' ],
             'selectors' => [
-                '{{WRAPPER}} .simple-hours-output .simple-hours-icon' => 'font-size: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .simple-hours-output .simple-hours-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
                 '{{WRAPPER}} .simple-hours-output .simple-hours-icon svg' => 'width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ] );
@@ -363,7 +372,9 @@ class SH_Elementor_Widget extends \Elementor\Widget_Base {
         $icon = '';
         if ( ! empty( $settings['text_icon']['value'] ) ) {
             $is_open    = SH_Shortcodes::is_open();
-            $icon_class = $is_open ? 'simple-hours-icon simple-hours-icon-open' : 'simple-hours-icon simple-hours-icon-closed';
+            $icon_class = $is_open
+                ? 'elementor-icon simple-hours-icon simple-hours-icon-open'
+                : 'elementor-icon simple-hours-icon simple-hours-icon-closed';
 
             ob_start();
             \Elementor\Icons_Manager::render_icon(


### PR DESCRIPTION
## Summary
- ensure icon color applies to built-in SVG and font icons in open or closed states
- add units and default size for icon slider and apply sizing to icon wrapper

## Testing
- `php -l includes/class-sh-elementor-widget.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bea504e488832c8fcf8ceca72b5627