### PR TITLE
Allow choosing 12‑hour or 24‑hour time display

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 1. Upload the `simple-hours` folder to your `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Go to Settings → Stoke Simple Hours to configure your weekly hours and holiday overrides.
-4. Optionally enable schema.org markup to output structured data for search engines.
+4. Select your preferred 12-hour or 24-hour time display.
+5. Optionally enable schema.org markup to output structured data for search engines.
 
 ## Usage
 

--- a/includes/class-sh-settings.php
+++ b/includes/class-sh-settings.php
@@ -7,6 +7,7 @@ class SH_Settings {
     const OPTION_SCHEMA_NAME = 'sh_schema_name';
     const OPTION_SCHEMA_TYPE = 'sh_schema_type';
     const OPTION_SECOND = 'sh_second_hours';
+    const OPTION_TIME_FORMAT = 'sh_time_format';
 
     public function __construct() {
         add_action('admin_menu', array($this,'add_admin_menu'));
@@ -26,9 +27,11 @@ class SH_Settings {
         register_setting('sh_settings', self::OPTION_SCHEMA_NAME);
         register_setting('sh_settings', self::OPTION_SCHEMA_TYPE);
         register_setting('sh_settings', self::OPTION_SECOND);
+        register_setting('sh_settings', self::OPTION_TIME_FORMAT);
 
         add_settings_section('sh_section', 'Settings', null, 'sh_settings');
 
+        add_settings_field('sh_time_format', 'Time Format', array($this,'time_format_render'), 'sh_settings','sh_section');
         add_settings_field('sh_second', 'Enable Second Hours', array($this,'second_render'), 'sh_settings','sh_section');
         add_settings_field('sh_weekly', 'Weekly Hours', array($this,'weekly_render'), 'sh_settings','sh_section');
         add_settings_field('sh_holidays','Holiday Overrides', array($this,'holidays_render'),'sh_settings','sh_section');
@@ -41,6 +44,14 @@ class SH_Settings {
             array($this, 'shortcodes_info'),
             'sh_settings'
         );
+    }
+
+    public function time_format_render(){
+        $val = get_option(self::OPTION_TIME_FORMAT, '24');
+        echo "<select name='".self::OPTION_TIME_FORMAT."'>";
+        echo "<option value='24' ".selected($val,'24',false).">24-hour</option>";
+        echo "<option value='12' ".selected($val,'12',false).">12-hour (AM/PM)</option>";
+        echo "</select>";
     }
 
     public function second_render(){

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -21,7 +21,7 @@ class SH_Shortcodes {
                 if ($today >= $h['from'] && $today <= $h['to']){
                     if (isset($h['closed'])) return "Sorry, we're closed today ({$h['label']}).";
                     $label = empty($h['label']) ? '' : " ({$h['label']})";
-                    return "We're open from {$h['open']} to {$h['close']}{$label}.";
+                    return "We're open from " . self::format_time($h['open']) . " to " . self::format_time($h['close']) . "{$label}.";
                 }
             }
         }
@@ -34,7 +34,7 @@ class SH_Shortcodes {
 
         $parts = array();
         foreach ($intervals as $i) {
-            $parts[] = $i[0] . ' to ' . $i[1];
+            $parts[] = self::format_time($i[0]) . ' to ' . self::format_time($i[1]);
         }
         return "We're open from " . implode(' and ', $parts) . ".";
     }
@@ -48,10 +48,10 @@ class SH_Shortcodes {
 
         foreach ($intervals as $i) {
             if ($time >= $i[0] && $time < $i[1]) {
-                return "Open today until {$i[1]}.";
+                return "Open today until " . self::format_time($i[1]) . ".";
             }
             if ($time < $i[0]) {
-                return "Next open at {$i[0]} today.";
+                return "Next open at " . self::format_time($i[0]) . " today.";
             }
         }
 
@@ -61,7 +61,7 @@ class SH_Shortcodes {
             $ints = self::get_intervals_for_date($weekly, $holidays, $d);
             if (!empty($ints)) {
                 $dn = date('l', strtotime($d));
-                return "Next open at {$ints[0][0]} on {$dn}.";
+                return "Next open at " . self::format_time($ints[0][0]) . " on {$dn}.";
             }
         }
     }
@@ -94,6 +94,17 @@ class SH_Shortcodes {
         return $out;
     }
 
+    private static function format_time($time){
+        $format = get_option(SH_Settings::OPTION_TIME_FORMAT, '24');
+        if ($format === '12') {
+            $dt = DateTime::createFromFormat('H:i', $time);
+            if ($dt) {
+                return $dt->format('g:i A');
+            }
+        }
+        return $time;
+    }
+
     public static function is_open($timestamp = null){
         list($weekly, $holidays) = self::get_data();
         $ts   = $timestamp ? $timestamp : time();
@@ -119,8 +130,8 @@ class SH_Shortcodes {
                     $hours1 = 'Closed';
                     $hours2 = '';
                 } else {
-                    $hours1 = !empty($v['open']) && !empty($v['close']) ? "{$v['open']} - {$v['close']}" : '';
-                    $hours2 = ($second && !empty($v['open2']) && !empty($v['close2'])) ? "{$v['open2']} - {$v['close2']}" : '';
+                    $hours1 = !empty($v['open']) && !empty($v['close']) ? self::format_time($v['open']) . ' - ' . self::format_time($v['close']) : '';
+                    $hours2 = ($second && !empty($v['open2']) && !empty($v['close2'])) ? self::format_time($v['open2']) . ' - ' . self::format_time($v['close2']) : '';
                 }
                 if ($second) {
                     $out .= "<tr{$row_class}><th class=\"simple-hours-day\">$day</th><td class=\"simple-hours-time\">$hours1</td><td class=\"simple-hours-time\">$hours2</td></tr>";

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -13,6 +13,7 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         ));
         update_option('sh_holiday_overrides', array());
         update_option('sh_second_hours', 0);
+        update_option('sh_time_format', '24');
     }
 
     public function test_today_shortcode_outputs_text() {
@@ -53,5 +54,11 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
 
         $output = do_shortcode('[simplehours_fullweek]');
         $this->assertStringContainsString('17:00 - 22:00', $output);
+    }
+
+    public function test_time_format_12_hour() {
+        update_option('sh_time_format', '12');
+        $output = do_shortcode('[simplehours_fullweek]');
+        $this->assertStringContainsString('9:00 AM - 5:00 PM', $output);
     }
 }


### PR DESCRIPTION
## Summary
- add `Time Format` setting to select 12-hour or 24-hour display
- format shortcode output according to selected time format
- document and test new time format option

## Testing
- `phpunit` *(fails: require_once(/tmp/includes/functions.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68beb571c210832cac9793f289f2bacc