### PR TITLE
Ensure tables default to transparent backgrounds

### DIFF
--- a/assets/simple-hours.css
+++ b/assets/simple-hours.css
@@ -6,3 +6,10 @@ table.simple-hours-table tr {
     background: none;
     padding: 0;
 }
+
+table.simple-hours-table tbody>tr:nth-child(odd)>td,
+table.simple-hours-table tbody>tr:nth-child(odd)>th,
+table.simple-hours-table tbody>tr:nth-child(even)>td,
+table.simple-hours-table tbody>tr:nth-child(even)>th {
+    background: none;
+}


### PR DESCRIPTION
## Summary
- Override Elementor's default zebra striping so Simple Hours tables remain transparent unless row colors are explicitly set.

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: Please set WP_TESTS_DIR environment variable.)*


------
https://chatgpt.com/codex/tasks/task_b_68beb7e081a0832caf67d39131b1e5bc