### PR TITLE
feat: support partial holiday closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 1. Upload the `simple-hours` folder to your `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Go to **Simple Hours** in the admin menu to configure your weekly hours and holiday overrides, including holiday messages.
+   - Holiday overrides now support start and finish times for partial-day closures.
+   - Holiday messages appear beneath the weekly hours table for easier styling.
 4. Select your preferred 12-hour or 24-hour time display.
 5. Optionally enable schema.org markup to output structured data for search engines.
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -4,6 +4,13 @@ jQuery(function($){
     row.find('input[type=time]').prop('disabled', $(this).is(':checked'));
   });
 
+  $(document).on('change', '.sh-holiday-closed', function(){
+    var row = $(this).closest('tr');
+    var checked = $(this).is(':checked');
+    row.find('input[name*="[open]"], input[name*="[close]"]').prop('disabled', checked);
+    row.find('input[name*="[start]"], input[name*="[finish]"]').prop('disabled', !checked);
+  });
+
   function toggleSecond(){
     var show = $('#sh_enable_second_hours').is(':checked');
     $('.sh-second-hours').toggle(show);
@@ -20,6 +27,8 @@ jQuery(function($){
       '<td><input type="date" name="sh_holiday_overrides['+index+'][to]" /></td>'+
       '<td><input type="text" name="sh_holiday_overrides['+index+'][label]" /></td>'+
       '<td><input type="checkbox" name="sh_holiday_overrides['+index+'][closed]" class="sh-holiday-closed" /></td>'+
+      '<td><input type="time" name="sh_holiday_overrides['+index+'][start]" disabled /></td>'+
+      '<td><input type="time" name="sh_holiday_overrides['+index+'][finish]" disabled /></td>'+
       '<td><input type="time" name="sh_holiday_overrides['+index+'][open]" /></td>'+
       '<td><input type="time" name="sh_holiday_overrides['+index+'][close]" /></td>'+
       '<td><button class="button sh-remove-holiday">Remove</button></td>'+

--- a/includes/class-sh-settings.php
+++ b/includes/class-sh-settings.php
@@ -95,7 +95,7 @@ class SH_Settings {
     public function holidays_render(){
         $values = get_option(self::OPTION_HOLIDAYS, array());
         echo '<table id="sh-holidays">';
-        echo '<tr><th>From</th><th>To</th><th>Label</th><th>Closed?</th><th>Open</th><th>Close</th><th>Action</th></tr>';
+        echo '<tr><th>From</th><th>To</th><th>Label</th><th>Closed?</th><th>Start</th><th>Finish</th><th>Open</th><th>Close</th><th>Action</th></tr>';
         if (is_array($values)){
             foreach($values as $i=>$h){
                 $from=esc_attr($h['from']);
@@ -104,11 +104,15 @@ class SH_Settings {
                 $closed=isset($h['closed'])?$h['closed']:false;
                 $open=esc_attr($h['open']??'');
                 $close=esc_attr($h['close']??'');
+                $start=esc_attr($h['start']??'');
+                $finish=esc_attr($h['finish']??'');
                 echo "<tr>";
                 echo "<td><input type='date' name='".self::OPTION_HOLIDAYS."[{$i}][from]' value='{$from}' /></td>";
                 echo "<td><input type='date' name='".self::OPTION_HOLIDAYS."[{$i}][to]' value='{$to}' /></td>";
                 echo "<td><input type='text' name='".self::OPTION_HOLIDAYS."[{$i}][label]' value='{$label}' /></td>";
                 echo "<td><input type='checkbox' name='".self::OPTION_HOLIDAYS."[{$i}][closed]' value='1' ".($closed?'checked':'')." class='sh-holiday-closed'></td>";
+                echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][start]' value='".($closed?$start:'')."' ".($closed?'':'disabled')." /></td>";
+                echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][finish]' value='".($closed?$finish:'')."' ".($closed?'':'disabled')." /></td>";
                 echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][open]' value='".($closed?'':$open)."' ".($closed?'disabled':'')." /></td>";
                 echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][close]' value='".($closed?'':$close)."' ".($closed?'disabled':'')." /></td>";
                 echo "<td><button class='button sh-remove-holiday'>Remove</button></td>";

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -18,8 +18,15 @@ class SH_Shortcodes {
 
         if (is_array($holidays)) {
             foreach ($holidays as $h) {
-                if ($today >= $h['from'] && $today <= $h['to']){
-                    if (isset($h['closed'])) return "Sorry, we're closed today ({$h['label']}).";
+                if ($today >= ($h['from'] ?? '') && $today <= ($h['to'] ?? '')){
+                    if (isset($h['closed'])) {
+                        $start  = $h['start'] ?? '';
+                        $finish = $h['finish'] ?? '';
+                        if (!$start || !$finish) {
+                            return "Sorry, we're closed today ({$h['label']}).";
+                        }
+                        break;
+                    }
                     $label = empty($h['label']) ? '' : " ({$h['label']})";
                     return "We're open from " . self::format_time($h['open']) . " to " . self::format_time($h['close']) . "{$label}.";
                 }
@@ -73,14 +80,27 @@ class SH_Shortcodes {
     }
 
     private static function get_intervals_for_date($weekly, $holidays, $date){
+        $base = self::get_weekly_intervals($weekly, $date);
+
         if (is_array($holidays)) {
             foreach ($holidays as $h) {
-                if ($date >= $h['from'] && $date <= $h['to']){
-                    if (isset($h['closed'])) return array();
+                if ($date >= ($h['from'] ?? '') && $date <= ($h['to'] ?? '')){
+                    if (isset($h['closed'])) {
+                        $start  = $h['start'] ?? '';
+                        $finish = $h['finish'] ?? '';
+                        if ($start && $finish) {
+                            return self::subtract_interval($base, $start, $finish);
+                        }
+                        return array();
+                    }
                     return array(array($h['open'], $h['close']));
                 }
             }
         }
+        return $base;
+    }
+
+    private static function get_weekly_intervals($weekly, $date){
         $dt = new DateTime($date, wp_timezone());
         $dn = $dt->format('l');
         if (!isset($weekly[$dn]) || !empty($weekly[$dn]['closed'])){
@@ -92,6 +112,24 @@ class SH_Shortcodes {
         }
         if (!empty($weekly[$dn]['open2']) && !empty($weekly[$dn]['close2'])) {
             $out[] = array($weekly[$dn]['open2'], $weekly[$dn]['close2']);
+        }
+        return $out;
+    }
+
+    private static function subtract_interval($intervals, $start, $finish){
+        $out = array();
+        foreach ($intervals as $int){
+            list($o, $c) = $int;
+            if ($finish <= $o || $start >= $c){
+                $out[] = $int;
+                continue;
+            }
+            if ($start > $o){
+                $out[] = array($o, $start);
+            }
+            if ($finish < $c){
+                $out[] = array($finish, $c);
+            }
         }
         return $out;
     }
@@ -154,17 +192,17 @@ class SH_Shortcodes {
             }
         }
 
-        $message = self::get_holiday_message($holidays);
+        $out .= '</table>';
+
+        $message = self::get_holiday_message($weekly, $holidays);
         if ($message) {
-            $colspan = $second ? 3 : 2;
-            $out .= '<tr class="simple-hours-holiday"><td colspan="' . $colspan . '" class="simple-hours-holiday-text">' . esc_html($message) . '</td></tr>';
+            $out .= '<div class="simple-hours-holiday-text">' . esc_html($message) . '</div>';
         }
 
-        $out .= '</table>';
         return $out;
     }
 
-    private static function get_holiday_message($holidays){
+    private static function get_holiday_message($weekly, $holidays){
         if (!is_array($holidays)) return '';
         $today = wp_date('Y-m-d');
         $limit = wp_date('Y-m-d', strtotime($today . ' +14 days'));
@@ -177,16 +215,26 @@ class SH_Shortcodes {
             $from = $h['from'] ?? '';
             $to   = $h['to'] ?? '';
             if (!$from || !$to) continue;
+            $reopen = self::get_next_open_date($weekly, $holidays, $to);
+            $end = wp_date(get_option('date_format'), strtotime($reopen));
             if ($today >= $from && $today <= $to) {
-                $end = wp_date(get_option('date_format'), strtotime($to));
                 return trim($pre_during) . ' ' . $h['label'] . ', ' . trim($post) . ' ' . $end;
             }
             if ($from > $today && $from <= $limit) {
-                $end = wp_date(get_option('date_format'), strtotime($to));
                 return trim($pre_before) . ' ' . $h['label'] . ' ' . trim($post) . ' ' . $end;
             }
         }
         return '';
+    }
+
+    private static function get_next_open_date($weekly, $holidays, $date){
+        $current = $date;
+        for ($i = 0; $i < 14; $i++) {
+            $ints = self::get_intervals_for_date($weekly, $holidays, $current);
+            if (!empty($ints)) return $current;
+            $current = wp_date('Y-m-d', strtotime($current . ' +1 day'));
+        }
+        return $date;
     }
 
 }

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -93,4 +93,26 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         $this->assertStringContainsString('Active Holiday', $output);
         $this->assertStringContainsString('We are closed for the', $output);
     }
+
+    public function test_partial_holiday_closure(){
+        update_option('sh_holiday_overrides', array(
+            array('from' => '2023-06-26', 'to' => '2023-06-26', 'label' => 'Morning Holiday', 'closed' => 1, 'start' => '09:00', 'finish' => '12:00')
+        ));
+        $closed_time = strtotime('2023-06-26 10:00:00');
+        $open_time = strtotime('2023-06-26 13:00:00');
+        $this->assertFalse( SH_Shortcodes::is_open( $closed_time ) );
+        $this->assertTrue( SH_Shortcodes::is_open( $open_time ) );
+    }
+
+    public function test_single_day_holiday_message_reopens_next_business_day(){
+        $today = wp_date('Y-m-d');
+        $next_monday = wp_date('Y-m-d', strtotime('next Monday', strtotime($today)));
+        update_option('sh_holiday_overrides', array(
+            array('from' => $next_monday, 'to' => $next_monday, 'label' => 'One Day Holiday', 'closed' => 1)
+        ));
+        $output = do_shortcode('[simplehours_fullweek]');
+        $reopen = wp_date(get_option('date_format'), strtotime($next_monday . ' +1 day'));
+        $this->assertStringContainsString($reopen, $output);
+    }
 }
+


### PR DESCRIPTION
## Summary
- allow start and finish times on holiday overrides
- show holiday notices beneath the hours table with next open business day
- add tests for partial-day closures

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: Please set WP_TESTS_DIR environment variable.)*

------
https://chatgpt.com/codex/tasks/task_b_68bfd675b578832cb996b83dc673fff0