### PR TITLE
Add holiday-message shortcode and simplify holiday overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Go to **Simple Hours** in the admin menu to configure your weekly hours and holiday overrides, including holiday messages.
    - Holiday overrides now support start and finish times for partial-day closures.
-   - Holiday messages appear beneath the weekly hours table for easier styling.
+   - Display holiday notices separately with the `[holiday-message]` shortcode.
 4. Select your preferred 12-hour or 24-hour time display.
 5. Optionally enable schema.org markup to output structured data for search engines.
 
@@ -16,6 +16,7 @@
   - `[simplehours_today]` – Today's hours
   - `[simplehours_until]` – Open today until
   - `[simplehours_fullweek]` – Full week table
+  - `[holiday-message]` – Current or upcoming holiday message
 
 - Elementor:
   - Add the **Stoke Simple Hours** widget and choose the output format along with text or table styling.

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -7,7 +7,6 @@ jQuery(function($){
   $(document).on('change', '.sh-holiday-closed', function(){
     var row = $(this).closest('tr');
     var checked = $(this).is(':checked');
-    row.find('input[name*="[open]"], input[name*="[close]"]').prop('disabled', checked);
     row.find('input[name*="[start]"], input[name*="[finish]"]').prop('disabled', !checked);
   });
 
@@ -29,8 +28,6 @@ jQuery(function($){
       '<td><input type="checkbox" name="sh_holiday_overrides['+index+'][closed]" class="sh-holiday-closed" /></td>'+
       '<td><input type="time" name="sh_holiday_overrides['+index+'][start]" disabled /></td>'+
       '<td><input type="time" name="sh_holiday_overrides['+index+'][finish]" disabled /></td>'+
-      '<td><input type="time" name="sh_holiday_overrides['+index+'][open]" /></td>'+
-      '<td><input type="time" name="sh_holiday_overrides['+index+'][close]" /></td>'+
       '<td><button class="button sh-remove-holiday">Remove</button></td>'+
     '</tr>';
     table.append(row);

--- a/includes/class-sh-schema.php
+++ b/includes/class-sh-schema.php
@@ -38,21 +38,6 @@ class SH_Schema {
             }
         }
 
-        if (is_array($holidays)) {
-            foreach ($holidays as $h) {
-                if (isset($h['closed'])) {
-                    continue;
-                }
-                $schema['openingHoursSpecification'][] = array(
-                    '@type'        => 'OpeningHoursSpecification',
-                    'validFrom'    => $h['from'],
-                    'validThrough' => $h['to'],
-                    'opens'        => $h['open'],
-                    'closes'       => $h['close'],
-                );
-            }
-        }
-
         if (! empty($schema['openingHoursSpecification'])) {
             echo "<script type='application/ld+json'>" . wp_json_encode($schema) . "</script>";
         }

--- a/includes/class-sh-settings.php
+++ b/includes/class-sh-settings.php
@@ -95,15 +95,13 @@ class SH_Settings {
     public function holidays_render(){
         $values = get_option(self::OPTION_HOLIDAYS, array());
         echo '<table id="sh-holidays">';
-        echo '<tr><th>From</th><th>To</th><th>Label</th><th>Closed?</th><th>Start</th><th>Finish</th><th>Open</th><th>Close</th><th>Action</th></tr>';
+        echo '<tr><th>From</th><th>To</th><th>Label</th><th>Closed?</th><th>Start</th><th>Finish</th><th>Action</th></tr>';
         if (is_array($values)){
             foreach($values as $i=>$h){
                 $from=esc_attr($h['from']);
                 $to=esc_attr($h['to']);
                 $label=esc_attr($h['label']);
                 $closed=isset($h['closed'])?$h['closed']:false;
-                $open=esc_attr($h['open']??'');
-                $close=esc_attr($h['close']??'');
                 $start=esc_attr($h['start']??'');
                 $finish=esc_attr($h['finish']??'');
                 echo "<tr>";
@@ -113,8 +111,6 @@ class SH_Settings {
                 echo "<td><input type='checkbox' name='".self::OPTION_HOLIDAYS."[{$i}][closed]' value='1' ".($closed?'checked':'')." class='sh-holiday-closed'></td>";
                 echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][start]' value='".($closed?$start:'')."' ".($closed?'':'disabled')." /></td>";
                 echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][finish]' value='".($closed?$finish:'')."' ".($closed?'':'disabled')." /></td>";
-                echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][open]' value='".($closed?'':$open)."' ".($closed?'disabled':'')." /></td>";
-                echo "<td><input type='time' name='".self::OPTION_HOLIDAYS."[{$i}][close]' value='".($closed?'':$close)."' ".($closed?'disabled':'')." /></td>";
                 echo "<td><button class='button sh-remove-holiday'>Remove</button></td>";
                 echo "</tr>";
             }
@@ -158,6 +154,7 @@ class SH_Settings {
         echo '<li><code>[simplehours_today]</code> – e.g. “We\'re open from 9:00 to 17:00.”</li>';
         echo '<li><code>[simplehours_until]</code> – e.g. “Open today until 17:00.”</li>';
         echo '<li><code>[simplehours_fullweek]</code> – outputs a full week table of hours.</li>';
+        echo '<li><code>[holiday-message]</code> – displays the current or upcoming holiday message.</li>';
         echo '</ul>';
     }
 

--- a/includes/class-sh-shortcodes.php
+++ b/includes/class-sh-shortcodes.php
@@ -4,6 +4,7 @@ class SH_Shortcodes {
         add_shortcode('simplehours_today', array(__CLASS__,'today'));
         add_shortcode('simplehours_until', array(__CLASS__,'until'));
         add_shortcode('simplehours_fullweek', array(__CLASS__,'fullweek'));
+        add_shortcode('holiday-message', array(__CLASS__,'holiday_message'));
     }
 
     public static function get_data(){
@@ -27,8 +28,6 @@ class SH_Shortcodes {
                         }
                         break;
                     }
-                    $label = empty($h['label']) ? '' : " ({$h['label']})";
-                    return "We're open from " . self::format_time($h['open']) . " to " . self::format_time($h['close']) . "{$label}.";
                 }
             }
         }
@@ -93,7 +92,6 @@ class SH_Shortcodes {
                         }
                         return array();
                     }
-                    return array(array($h['open'], $h['close']));
                 }
             }
         }
@@ -193,12 +191,6 @@ class SH_Shortcodes {
         }
 
         $out .= '</table>';
-
-        $message = self::get_holiday_message($weekly, $holidays);
-        if ($message) {
-            $out .= '<div class="simple-hours-holiday-text">' . esc_html($message) . '</div>';
-        }
-
         return $out;
     }
 
@@ -235,6 +227,15 @@ class SH_Shortcodes {
             $current = wp_date('Y-m-d', strtotime($current . ' +1 day'));
         }
         return $date;
+    }
+
+    public static function holiday_message(){
+        list($weekly, $holidays) = self::get_data();
+        $message = self::get_holiday_message($weekly, $holidays);
+        if ($message){
+            return '<div class="simple-hours-holiday-text">' . esc_html($message) . '</div>';
+        }
+        return '';
     }
 
 }

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -72,26 +72,28 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         $this->assertTrue( SH_Shortcodes::is_open( $ts ) );
     }
 
-    public function test_fullweek_shows_upcoming_holiday_message() {
+    public function test_holiday_message_shortcode_upcoming() {
         $today = wp_date('Y-m-d');
         $from = wp_date('Y-m-d', strtotime($today . ' +7 days'));
         $to   = wp_date('Y-m-d', strtotime($today . ' +10 days'));
         update_option('sh_holiday_overrides', array(
             array('from' => $from, 'to' => $to, 'label' => 'Test Holiday', 'closed' => 1)
         ));
-        $output = do_shortcode('[simplehours_fullweek]');
-        $this->assertStringContainsString('Test Holiday', $output);
+        $fullweek = do_shortcode('[simplehours_fullweek]');
+        $message = do_shortcode('[holiday-message]');
+        $this->assertStringNotContainsString('Test Holiday', $fullweek);
+        $this->assertStringContainsString('Test Holiday', $message);
     }
 
-    public function test_fullweek_shows_active_holiday_message() {
+    public function test_holiday_message_shortcode_active() {
         $today = wp_date('Y-m-d');
         $to   = wp_date('Y-m-d', strtotime($today . ' +3 days'));
         update_option('sh_holiday_overrides', array(
             array('from' => $today, 'to' => $to, 'label' => 'Active Holiday', 'closed' => 1)
         ));
-        $output = do_shortcode('[simplehours_fullweek]');
-        $this->assertStringContainsString('Active Holiday', $output);
-        $this->assertStringContainsString('We are closed for the', $output);
+        $message = do_shortcode('[holiday-message]');
+        $this->assertStringContainsString('Active Holiday', $message);
+        $this->assertStringContainsString('We are closed for the', $message);
     }
 
     public function test_partial_holiday_closure(){
@@ -104,15 +106,15 @@ class SimpleHours_Shortcodes_Test extends WP_UnitTestCase {
         $this->assertTrue( SH_Shortcodes::is_open( $open_time ) );
     }
 
-    public function test_single_day_holiday_message_reopens_next_business_day(){
+    public function test_holiday_message_reopens_next_business_day(){
         $today = wp_date('Y-m-d');
         $next_monday = wp_date('Y-m-d', strtotime('next Monday', strtotime($today)));
         update_option('sh_holiday_overrides', array(
             array('from' => $next_monday, 'to' => $next_monday, 'label' => 'One Day Holiday', 'closed' => 1)
         ));
-        $output = do_shortcode('[simplehours_fullweek]');
+        $message = do_shortcode('[holiday-message]');
         $reopen = wp_date(get_option('date_format'), strtotime($next_monday . ' +1 day'));
-        $this->assertStringContainsString($reopen, $output);
+        $this->assertStringContainsString($reopen, $message);
     }
 }
 


### PR DESCRIPTION
## Summary
- drop open/close fields from holiday overrides, leaving only start/finish times
- add `[holiday-message]` shortcode and list it in plugin settings
- remove holiday notice from weekly table output and update tests

## Testing
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_b_68bfd94472e8832cb6f0dcd2aee038d0